### PR TITLE
Refactor : inventory jpa -> query dsl전환

### DIFF
--- a/src/main/java/com/seahere/backend/inventory/controller/InventoryReqController.java
+++ b/src/main/java/com/seahere/backend/inventory/controller/InventoryReqController.java
@@ -9,6 +9,7 @@ import com.seahere.backend.inventory.controller.response.InventoryReqListRespons
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -25,7 +26,7 @@ public class InventoryReqController {
     @GetMapping
     public ResponseEntity<InventoryReqListResponse> inventoryReqList(InventoryReqSearchRequest searchRequest) {
         PageRequest pageRequest = PageRequest.of(searchRequest.getPage(), searchRequest.getSize(), Sort.by(Sort.Direction.ASC, "name"));
-        Page<InventoryReqDto> results = inventoryService.findPagedInventoryByCompanyId(searchRequest.getCompanyId(), pageRequest, searchRequest.getSearch());
+        Slice<InventoryReqDto> results = inventoryService.findPagedInventoryByCompanyId(searchRequest.getCompanyId(), pageRequest, searchRequest.getSearch());
         InventoryReqListResponse inventoryReqListResponse = new InventoryReqListResponse(results);
         return ResponseEntity.ok(inventoryReqListResponse);
     }
@@ -33,7 +34,7 @@ public class InventoryReqController {
     @GetMapping("/details")
     public ResponseEntity<InventoryReqDetailListResponse> inventoryReqDetailList(InventoryReqDetailSearchRequest detailSearchRequest) {
         PageRequest pageRequest = PageRequest.of(detailSearchRequest.getPage(), detailSearchRequest.getSize(), Sort.by(Sort.Direction.ASC, "incomingDate"));
-        Page<InventoryReqDetailDto> results = inventoryService.findPagedProductsByCompanyId(detailSearchRequest.getCompanyId(), detailSearchRequest.getName(), detailSearchRequest.getCategory(), pageRequest);
+        Slice<InventoryReqDetailDto> results = inventoryService.findPagedProductsByCompanyId(detailSearchRequest.getCompanyId(), detailSearchRequest.getName(), detailSearchRequest.getCategory(), pageRequest);
         InventoryReqDetailListResponse inventoryReqDetailListResponse = new InventoryReqDetailListResponse(results);
         return ResponseEntity.ok(inventoryReqDetailListResponse);
     }

--- a/src/main/java/com/seahere/backend/inventory/controller/request/InventoryReqDetailSearchRequest.java
+++ b/src/main/java/com/seahere/backend/inventory/controller/request/InventoryReqDetailSearchRequest.java
@@ -9,8 +9,8 @@ import lombok.*;
 @Builder
 public class InventoryReqDetailSearchRequest {
     private Long companyId;
-    private int size = 10;
-    private int page = 0;
+    private int size;
+    private int page;
     private String name;
     private String category;
 }

--- a/src/main/java/com/seahere/backend/inventory/controller/request/InventoryReqUpdateRequest.java
+++ b/src/main/java/com/seahere/backend/inventory/controller/request/InventoryReqUpdateRequest.java
@@ -7,8 +7,9 @@ import lombok.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class InventoryReqSearchRequest {
+public class InventoryReqUpdateRequest {
     private Long companyId;
+    private Long inventoryId;
     private int size;
     private int page;
     private String search;

--- a/src/main/java/com/seahere/backend/inventory/controller/response/InventoryReqDetailDto.java
+++ b/src/main/java/com/seahere/backend/inventory/controller/response/InventoryReqDetailDto.java
@@ -1,30 +1,21 @@
 package com.seahere.backend.inventory.controller.response;
 
-import lombok.Getter;
-import lombok.ToString;
+import lombok.*;
 
 import java.time.LocalDate;
 
-@Getter
 @ToString
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class InventoryReqDetailDto {
     private Long inventoryId;
     private Long companyId;
     private String name;
     private String category;
-    private int quantity;
+    private Long quantity;
     private LocalDate incomingDate;
     private String country;
     private String naturalStatus;
 
-    public InventoryReqDetailDto(Long inventoryId, Long companyId, String name, String category, int quantity, LocalDate incomingDate, String country, String naturalStatus) {
-        this.inventoryId = inventoryId;
-        this.companyId = companyId;
-        this.name = name;
-        this.category = category;
-        this.quantity = quantity;
-        this.incomingDate = incomingDate;
-        this.country = country;
-        this.naturalStatus = naturalStatus;
-    }
 }

--- a/src/main/java/com/seahere/backend/inventory/controller/response/InventoryReqDetailListResponse.java
+++ b/src/main/java/com/seahere/backend/inventory/controller/response/InventoryReqDetailListResponse.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 @Getter
 public class InventoryReqDetailListResponse {
-    private final List<InventoryReqDetailDto> content;
+    private final Slice<InventoryReqDetailDto> content;
     private final SortResponse sort;
     private final int currentPage;
     private final int size;
@@ -17,7 +17,7 @@ public class InventoryReqDetailListResponse {
     private final boolean hasNext;
 
     public InventoryReqDetailListResponse(Slice<InventoryReqDetailDto> slice) {
-        this.content = slice.getContent(); // 이미 InventoryReqDto 객체들이므로 변환 필요 없음
+        this.content = slice; // 이미 InventoryReqDto 객체들이므로 변환 필요 없음
         this.sort = new SortResponse(slice.getSort());
         this.currentPage = slice.getNumber();
         this.size = slice.getSize();

--- a/src/main/java/com/seahere/backend/inventory/controller/response/InventoryReqDetailListResponse.java
+++ b/src/main/java/com/seahere/backend/inventory/controller/response/InventoryReqDetailListResponse.java
@@ -17,7 +17,7 @@ public class InventoryReqDetailListResponse {
     private final boolean hasNext;
 
     public InventoryReqDetailListResponse(Slice<InventoryReqDetailDto> slice) {
-        this.content = slice; // 이미 InventoryReqDto 객체들이므로 변환 필요 없음
+        this.content = slice;
         this.sort = new SortResponse(slice.getSort());
         this.currentPage = slice.getNumber();
         this.size = slice.getSize();

--- a/src/main/java/com/seahere/backend/inventory/controller/response/InventoryReqDto.java
+++ b/src/main/java/com/seahere/backend/inventory/controller/response/InventoryReqDto.java
@@ -1,14 +1,16 @@
 package com.seahere.backend.inventory.controller.response;
 
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.time.LocalDate;
 
-@Builder
-@Getter
-@AllArgsConstructor
-@NoArgsConstructor
 @ToString
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class InventoryReqDto {
     private Long companyId;
     private String name;

--- a/src/main/java/com/seahere/backend/inventory/controller/response/InventoryReqListResponse.java
+++ b/src/main/java/com/seahere/backend/inventory/controller/response/InventoryReqListResponse.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 @Getter
 public class InventoryReqListResponse {
-    private final List<InventoryReqDto> content;
+    private final Slice<InventoryReqDto> content;
     private final SortResponse sort;
     private final int currentPage;
     private final int size;
@@ -17,7 +17,7 @@ public class InventoryReqListResponse {
     private final boolean hasNext;
 
     public InventoryReqListResponse(Slice<InventoryReqDto> slice) {
-        this.content = slice.getContent(); // 이미 InventoryReqDto 객체들이므로 변환 필요 없음
+        this.content = slice; // 이미 InventoryReqDto 객체들이므로 변환 필요 없음
         this.sort = new SortResponse(slice.getSort());
         this.currentPage = slice.getNumber();
         this.size = slice.getSize();

--- a/src/main/java/com/seahere/backend/inventory/entity/InventoryEntity.java
+++ b/src/main/java/com/seahere/backend/inventory/entity/InventoryEntity.java
@@ -1,5 +1,6 @@
 package com.seahere.backend.inventory.entity;
 
+import com.seahere.backend.company.entity.CompanyEntity;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,8 +21,9 @@ public class InventoryEntity {
     @Column(name = "inventory_id")
     private Long inventoryId;
 
-    @Column(name = "company_id")
-    private Long companyId;
+    @ManyToOne
+    @JoinColumn(name = "company_id")
+    private CompanyEntity company;
 
     @Column(name = "quantity")
     private int quantity;

--- a/src/main/java/com/seahere/backend/inventory/repository/InventoryJpaRepository.java
+++ b/src/main/java/com/seahere/backend/inventory/repository/InventoryJpaRepository.java
@@ -11,18 +11,18 @@ import org.springframework.data.repository.query.Param;
 
 public interface InventoryJpaRepository extends JpaRepository<InventoryEntity, Long> {
 
-    @Query("SELECT new com.seahere.backend.inventory.controller.response.InventoryReqDto(" +
-            "i.companyId, i.name, i.category, MAX(i.incomingDate), SUM(i.quantity)) " +
-            "FROM InventoryEntity i WHERE i.companyId = :companyId AND i.name LIKE %:search% GROUP BY i.name, i.category")
-    Page<InventoryReqDto> findPagedInventoryByCompanyId(@Param("companyId") Long companyId,
-                                                        @Param("search") String search,
-                                                        Pageable pageable);
+//    @Query("SELECT new com.seahere.backend.inventory.controller.response.InventoryReqDto(" +
+//            "i.company.id, i.name, i.category, MAX(i.incomingDate), SUM(i.quantity)) " +
+//            "FROM InventoryEntity i WHERE i.company.id = :companyId AND i.name LIKE %:search% GROUP BY i.name, i.category")
+//    Page<InventoryReqDto> findPagedInventoryByCompanyId(@Param("companyId") Long companyId,
+//                                                        @Param("search") String search,
+//                                                        Pageable pageable);
 
-    @Query("SELECT new com.seahere.backend.inventory.controller.response.InventoryReqDetailDto(" +
-            "i.inventoryId, i.companyId, i.name, i.category, i.quantity, i.incomingDate, i.country, i.naturalStatus) " +
-            "FROM InventoryEntity i WHERE i.companyId = :companyId AND i.name = :name AND i.category = :category")
-    Page<InventoryReqDetailDto> findPagedProductsByCompanyId(@Param("companyId") Long companyId,
-                                                             @Param("name") String name,
-                                                             @Param("category") String category,
-                                                             Pageable pageable);
+//    @Query("SELECT new com.seahere.backend.inventory.controller.response.InventoryReqDetailDto(" +
+//            "i.inventoryId, i.company.id, i.name, i.category, i.quantity, i.incomingDate, i.country, i.naturalStatus) " +
+//            "FROM InventoryEntity i WHERE i.company.id = :companyId AND i.name = :name AND i.category = :category")
+//    Page<InventoryReqDetailDto> findPagedProductsByCompanyId(@Param("companyId") Long companyId,
+//                                                             @Param("name") String name,
+//                                                             @Param("category") String category,
+//                                                             Pageable pageable);
 }

--- a/src/main/java/com/seahere/backend/inventory/repository/InventoryRepository.java
+++ b/src/main/java/com/seahere/backend/inventory/repository/InventoryRepository.java
@@ -1,10 +1,77 @@
 package com.seahere.backend.inventory.repository;
 
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.seahere.backend.inventory.controller.response.InventoryReqDetailDto;
+import com.seahere.backend.inventory.controller.response.InventoryReqDto;
+import com.seahere.backend.inventory.entity.QInventoryEntity;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
 public class InventoryRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    private static final QInventoryEntity inventory = QInventoryEntity.inventoryEntity;
+
+    public Slice<InventoryReqDto> findPagedInventoryByCompanyId(Long companyId, String search, Pageable pageable) {
+        List<InventoryReqDto> results = queryFactory
+                .select(Projections.constructor(InventoryReqDto.class,
+                        inventory.company.id,
+                        inventory.name,
+                        inventory.category,
+                        inventory.incomingDate.max(),
+                        Expressions.asNumber(inventory.quantity.sum()).longValue()))
+                .from(inventory)
+                .where(inventory.company.id.eq(companyId)
+                        .and(inventory.name.containsIgnoreCase(search)))
+                .groupBy(inventory.name, inventory.category, inventory.company.id)
+                .orderBy(inventory.name.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        boolean hasNext = results.size() > pageable.getPageSize();
+        if (hasNext) {
+            results = results.subList(0, pageable.getPageSize());
+        }
+
+        return new SliceImpl<>(results, pageable, hasNext);
+    }
+
+    public Slice<InventoryReqDetailDto> findPagedProductsByCompanyId(Long companyId, String name, String category, Pageable pageable) {
+        List<InventoryReqDetailDto> results = queryFactory
+                .select(Projections.constructor(InventoryReqDetailDto.class,
+                        inventory.inventoryId,
+                        inventory.company.id,
+                        inventory.name,
+                        inventory.category,
+                        Expressions.asNumber(inventory.quantity).longValue(),
+                        inventory.incomingDate,
+                        inventory.country,
+                        inventory.naturalStatus))
+                .from(inventory)
+                .where(inventory.company.id.eq(companyId)
+                        .and(inventory.name.eq(name))
+                        .and(inventory.category.eq(category)))
+                .orderBy(inventory.incomingDate.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1)
+                .fetch();
+
+        boolean hasNext = results.size() > pageable.getPageSize();
+        if (hasNext) {
+            results = results.subList(0, pageable.getPageSize());
+        }
+
+        return new SliceImpl<>(results, pageable, hasNext);
+    }
 }

--- a/src/main/java/com/seahere/backend/inventory/service/InventoryService.java
+++ b/src/main/java/com/seahere/backend/inventory/service/InventoryService.java
@@ -3,22 +3,24 @@ package com.seahere.backend.inventory.service;
 import com.seahere.backend.inventory.controller.response.InventoryReqDetailDto;
 import com.seahere.backend.inventory.controller.response.InventoryReqDto;
 import com.seahere.backend.inventory.repository.InventoryJpaRepository;
+import com.seahere.backend.inventory.repository.InventoryRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class InventoryService {
-    private final InventoryJpaRepository inventoryJpaRepository;
+    private final InventoryRepository inventoryRepository;
 
-    public Page<InventoryReqDto> findPagedInventoryByCompanyId(Long companyId, Pageable pageable, String search) {
-        return inventoryJpaRepository.findPagedInventoryByCompanyId(companyId, search, pageable);
+    public Slice<InventoryReqDto> findPagedInventoryByCompanyId(Long companyId, Pageable pageable, String search) {
+        return inventoryRepository.findPagedInventoryByCompanyId(companyId, search, pageable);
     }
 
-    public Page<InventoryReqDetailDto> findPagedProductsByCompanyId(Long companyId, String name, String category, PageRequest pageable) {
-        return inventoryJpaRepository.findPagedProductsByCompanyId(companyId, name, category, pageable);
+    public Slice<InventoryReqDetailDto> findPagedProductsByCompanyId(Long companyId, String name, String category, PageRequest pageable) {
+        return inventoryRepository.findPagedProductsByCompanyId(companyId, name, category, pageable);
     }
 }

--- a/src/main/java/com/seahere/backend/outgoing/repository/OutgoingRepository.java
+++ b/src/main/java/com/seahere/backend/outgoing/repository/OutgoingRepository.java
@@ -36,6 +36,7 @@ public class OutgoingRepository {
         }
         return new SliceImpl<>(results,pageable, hasNext);
     }
+
     private BooleanExpression outgoingStateIsPending(CompanyEntity company,LocalDate startDate, LocalDate endDate, String search) {
         return outgoingEntity.outgoingState.eq(OutgoingState.PENDING)
                 .and(outgoingEntity.company.eq(company))

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,4 +1,5 @@
-INSERT INTO company(company_id) VALUES (1);
+INSERT INTO company(company_id) VALUES (101);
+INSERT INTO company(company_id) VALUES (102);
 insert into USERS(user_id) values(2);
 
 INSERT INTO outgoing (outgoing_id, company_id, outgoing_date, outgoing_state, partial_outgoing,customer_name) VALUES

--- a/src/test/java/com/seahere/backend/inventory/controller/InventoryControllerTest.java
+++ b/src/test/java/com/seahere/backend/inventory/controller/InventoryControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.seahere.backend.inventory.controller.request.InventoryReqDetailSearchRequest;
 import com.seahere.backend.inventory.controller.request.InventoryReqSearchRequest;
 import com.seahere.backend.inventory.repository.InventoryJpaRepository;
+import com.seahere.backend.inventory.repository.InventoryRepository;
 import com.seahere.backend.inventory.service.InventoryService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -27,7 +28,7 @@ public class InventoryControllerTest {
     InventoryService inventoryService;
 
     @Autowired
-    InventoryJpaRepository inventoryJpaRepository;
+    InventoryRepository inventoryRepository;
 
     @Autowired
     ObjectMapper objectMapper;
@@ -88,6 +89,48 @@ public class InventoryControllerTest {
                 .size(10)
                 .page(0)
                 .search("광어")
+                .build();
+
+        //expect
+        mockMvc.perform(get("/inventories")
+                        .param("companyId", String.valueOf(inventoryReqSearchRequest.getCompanyId()))
+                        .param("size", String.valueOf(inventoryReqSearchRequest.getSize()))
+                        .param("page", String.valueOf(inventoryReqSearchRequest.getPage()))
+                        .param("search", inventoryReqSearchRequest.getSearch()))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("재고가 없을 경우 content에 null을 반환된다.")
+    public void test4() throws Exception {
+        //given
+        InventoryReqSearchRequest inventoryReqSearchRequest = InventoryReqSearchRequest.builder()
+                .companyId(102L)
+                .size(10)
+                .page(0)
+                .search("")
+                .build();
+
+        //expect
+        mockMvc.perform(get("/inventories")
+                        .param("companyId", String.valueOf(inventoryReqSearchRequest.getCompanyId()))
+                        .param("size", String.valueOf(inventoryReqSearchRequest.getSize()))
+                        .param("page", String.valueOf(inventoryReqSearchRequest.getPage()))
+                        .param("search", inventoryReqSearchRequest.getSearch()))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("재고보다 많은 페이지를 param으로 넣을 경우 content에 null을 반환된다.")
+    public void test5() throws Exception {
+        //given
+        InventoryReqSearchRequest inventoryReqSearchRequest = InventoryReqSearchRequest.builder()
+                .companyId(102L)
+                .size(10)
+                .page(3)
+                .search("")
                 .build();
 
         //expect

--- a/src/test/java/com/seahere/backend/inventory/controller/InventoryControllerTest.java
+++ b/src/test/java/com/seahere/backend/inventory/controller/InventoryControllerTest.java
@@ -3,7 +3,6 @@ package com.seahere.backend.inventory.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.seahere.backend.inventory.controller.request.InventoryReqDetailSearchRequest;
 import com.seahere.backend.inventory.controller.request.InventoryReqSearchRequest;
-import com.seahere.backend.inventory.repository.InventoryJpaRepository;
 import com.seahere.backend.inventory.repository.InventoryRepository;
 import com.seahere.backend.inventory.service.InventoryService;
 import org.junit.jupiter.api.DisplayName;
@@ -14,7 +13,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/src/test/java/com/seahere/backend/inventory/service/InventoryServiceTest.java
+++ b/src/test/java/com/seahere/backend/inventory/service/InventoryServiceTest.java
@@ -1,26 +1,24 @@
 package com.seahere.backend.inventory.service;
 
-import com.seahere.backend.inventory.controller.response.InventoryReqDetailDto;
 import com.seahere.backend.inventory.controller.response.InventoryReqDto;
-import com.seahere.backend.inventory.repository.InventoryJpaRepository;
+import com.seahere.backend.inventory.repository.InventoryRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.Sort;
 import org.springframework.test.context.jdbc.Sql;
 
-@Sql(value = "/sql/inventory-service-test.sql",executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(value = "/sql/inventory-service-test.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
 @Slf4j
 @SpringBootTest
 class InventoryServiceTest {
+
     @Autowired
-    InventoryService inventoryService;
-    @Autowired
-    InventoryJpaRepository inventoryJpaRepository;
+    InventoryRepository inventoryRepository;
 
     @Test
     @DisplayName("companyId를 통한 재고 목록 조회")
@@ -29,18 +27,9 @@ class InventoryServiceTest {
         Long companyId = 101L;
         String search = "";
         PageRequest pageRequest = PageRequest.of(0, 10, Sort.by(Sort.Direction.ASC, "name"));
-        Page<InventoryReqDto> inventoryReqDtoSlice = inventoryJpaRepository.findPagedInventoryByCompanyId(companyId, search, pageRequest);
-        Page<InventoryReqDetailDto> inventoryReqDetailDtoPage1 = inventoryJpaRepository.findPagedProductsByCompanyId(companyId, "광어", "활어", pageRequest);
-        inventoryReqDtoSlice.forEach(inventory -> log.info("Inventory: {}", inventory.toString()));
-        inventoryReqDetailDtoPage1.forEach(product -> log.info("Product before remove: {}", product.toString()));
-        inventoryJpaRepository.deleteById(1L);
+        Slice<InventoryReqDto> inventoryReqDtoSlice = inventoryRepository.findPagedInventoryByCompanyId(companyId, search, pageRequest);
 
         // then
-        Page<InventoryReqDetailDto> inventoryReqDetailDtoPage2 = inventoryJpaRepository.findPagedProductsByCompanyId(companyId, "광어", "활어", pageRequest);
-
-        inventoryReqDetailDtoPage2.forEach(product -> log.info("Product after remove: {}", product.toString()));
-
-
+        inventoryReqDtoSlice.forEach(inventory -> log.info("Inventory: {}", inventory.toString()));
     }
-
 }

--- a/src/test/resources/sql/inventory-service-test.sql
+++ b/src/test/resources/sql/inventory-service-test.sql
@@ -1,4 +1,7 @@
 DELETE FROM inventories;
+DELETE FROM company;
+INSERT INTO company(company_id) VALUES (101);
+INSERT INTO company(company_id) VALUES (102);
 
 INSERT INTO inventories (inventory_id, company_id, quantity, category, name, country, incoming_date, natural_status) VALUES
                                                                                                                          (1, 101, 60, '활어', '광어', '국산', '2024-07-23', '자연'),
@@ -10,7 +13,7 @@ INSERT INTO inventories (inventory_id, company_id, quantity, category, name, cou
                                                                                                                          (7, 101, 17, '활어', '우럭', '국산', '2024-07-28', '양식'),
                                                                                                                          (8, 101, 60, '활어', '광어', '국산', '2024-07-03', '자연'),
                                                                                                                          (9, 101, 60, '활어', '광어', '국산', '2024-07-17', '자연'),
-                                                                                                                         (10, 101, 60,'활어', '숭어', '국산', '2024-07-23', '양식'),
+                                                                                                                         (10, 101, 60, '활어', '숭어', '국산', '2024-07-23', '양식'),
                                                                                                                          (11, 101, 60, '활어', '광어', '국산', '2024-07-23', '자연'),
                                                                                                                          (12, 101, 60, '활어', '광어', '국산', '2024-07-31', '자연'),
                                                                                                                          (13, 101, 10, '활어', '민어', '국산', '2024-07-28', '자연'),


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #23 

## 📝작업 내용

> 재고 조회 기능 jpa에서 쿼리 dsl로 전환

### 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/ff5eaec0-542d-4bbf-86b6-efdf23216c6d)
![image](https://github.com/user-attachments/assets/fdbf3a54-86dc-4aee-a835-408e5a52c528)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
